### PR TITLE
Making minimal changes to allow crate to be built using a non wasm target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1](https://github.com/streamingfast/substreams-rs/releases/tag/v0.2.1)
+
+* Added conditional compilation to make sure code that is linked to wasm modules can only be compiled when a wasm target is specified. Non-wasm targets will skip compiling the linked code allowing the crate to be compiled with any target.
+
 ## [0.2.0](https://github.com/streamingfast/substreams-rs/releases/tag/v0.2.0)
 
 ### Breaking changes

--- a/substreams/src/lib.rs
+++ b/substreams/src/lib.rs
@@ -62,7 +62,7 @@
 //! #   use substreams::pb::substreams::StoreDelta;
 //! #   use substreams::store::Delta;
 //! #   pub type Custom = ();
-//! #   
+//! #
 //! #   #[derive(Clone, PartialEq, ::prost::Message)]
 //! #   pub struct Pairs {}
 //! #   #[derive(Clone, PartialEq, ::prost::Message)]
@@ -89,6 +89,7 @@
 extern crate core;
 
 pub mod errors;
+#[cfg(target_arch = "wasm32")]
 mod externs;
 pub mod handlers;
 mod hex;
@@ -99,12 +100,15 @@ pub mod memory;
 pub mod pb;
 pub mod proto;
 pub mod scalar;
+#[cfg(target_arch = "wasm32")]
 mod state;
+#[cfg(target_arch = "wasm32")]
 pub mod store;
 
 pub use crate::hex::Hex;
 pub use hex_literal::hex;
 
+#[cfg(target_arch = "wasm32")]
 pub fn output<M: prost::Message>(msg: M) {
     // Need to return the buffer and forget about it issue occurred when trying to write large data
     // wasm was "dropping" the data before we could write to it, which causes us to have garbage
@@ -116,11 +120,13 @@ pub fn output<M: prost::Message>(msg: M) {
 }
 
 ///
+#[cfg(target_arch = "wasm32")]
 pub fn output_raw(data: Vec<u8>) {
     unsafe { externs::output(data.as_ptr(), data.len() as u32) }
 }
 
 /// Registers a Substreams custom panic hook. The panic hook is invoked when then handler panics
+#[cfg(target_arch = "wasm32")]
 pub fn register_panic_hook() {
     use std::sync::Once;
     static SET_HOOK: Once = Once::new();
@@ -129,6 +135,7 @@ pub fn register_panic_hook() {
     });
 }
 
+#[cfg(target_arch = "wasm32")]
 fn hook(info: &std::panic::PanicInfo<'_>) {
     let error_msg = info
         .payload()

--- a/substreams/src/log.rs
+++ b/substreams/src/log.rs
@@ -4,6 +4,7 @@
 //! in your handlers
 //!
 
+#[cfg(target_arch = "wasm32")]
 use crate::externs;
 
 /// Logs a message at INFO level on the logger of the current substream using interpolation of
@@ -86,6 +87,10 @@ pub use log_info as info;
 pub fn println<T: AsRef<str>>(msg: T) {
     let reference = msg.as_ref();
 
+    #[cfg(not(target_arch = "wasm32"))]
+    println!("{}", reference);
+
+    #[cfg(target_arch = "wasm32")]
     unsafe {
         externs::println(reference.as_ptr(), reference.len());
     }


### PR DESCRIPTION
Adding the minimum changes required to allow the substreams crate to be built using a non wasm target (eg. you would need this if this is included as a dependency in a build.rs file).  

NB The [substreams-ethereum](https://github.com/streamingfast/substreams-ethereum) crate uses this crate as a dependency so a change to that crate will also be required after to reference this updated version.